### PR TITLE
fix #248: getters and setters will cause error when initializing the suite

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,9 @@
 {
   "packages": [
-    "packages/@testdeck/*"
+    "packages/@testdeck/core",
+    "packages/@testdeck/jasmine",
+    "packages/@testdeck/mocha",
+    "packages/@testdeck/jest"
   ],
   "command": {
     "bootstrap": {

--- a/packages/@testdeck/core/index.ts
+++ b/packages/@testdeck/core/index.ts
@@ -133,11 +133,18 @@ export abstract class ClassTestUI {
       let currentPrototype = prototype;
       while (currentPrototype !== Object.prototype) {
         Object.getOwnPropertyNames(currentPrototype).forEach((key) => {
-          if (typeof prototype[key] === "function") {
-            const method = prototype[key];
-            if (method[ClassTestUI.nameSymbol] && !collectedTests[key]) {
-              collectedTests[key] = [prototype, method];
+          // Issue #248: getters and setters declared by classes may result in error
+          // and accessing the property by name will directly invoke either one
+          try {
+            if (typeof prototype[key] === "function") {
+              const method = prototype[key];
+              if (method[ClassTestUI.nameSymbol] && !collectedTests[key]) {
+                collectedTests[key] = [prototype, method];
+              }
             }
+          } catch (ignored) {
+            // getter or setter
+            // just ignore, even though it is a costly operation
           }
         });
         currentPrototype = (Object as any).getPrototypeOf(currentPrototype);

--- a/packages/@testdeck/core/test.ts
+++ b/packages/@testdeck/core/test.ts
@@ -887,6 +887,38 @@ describe("testdeck", function() {
             );
         });
     });
+
+    describe("regression #248: getters and setters are invoked during initialization of the suite", function() {
+
+      it("must not fail on getter or setter during initialization of the test suite", function() {
+
+        class Issue248Base {
+
+          private readonly mStrings: Set<string>;
+
+          constructor() {
+            this.mStrings = new Set<string>();
+          }
+
+          get strings(): string[] {
+            return Array.from(this.mStrings);
+          }
+        }
+
+        @ui.suite
+        class Issue248Test extends Issue248Base {
+
+          constructor() {
+            super();
+          }
+
+          @ui.test
+          private testFoo() {
+            const _ = this.strings;
+          }
+        }
+      });
+    });
 });
 
 declare var setTimeout;


### PR DESCRIPTION
- temporarily disabling the di-typedi package as there are unrelated errors