### PR TITLE
let npm resolve mocka and tsc binary

### DIFF
--- a/packages/@testdeck/mocha/bin/watch
+++ b/packages/@testdeck/mocha/bin/watch
@@ -18,8 +18,8 @@ const argv = yargs
       t: {
           alias: "tsc",
           demand: false,
-          default: "./node_modules/typescript/bin/tsc",
-          describe: "Path to executable tsc, by default points to typescript installed as dev dependency. Set to 'tsc' for global tsc installation.",
+          default: "tsc",
+          describe: "Path to executable tsc, by default points to typescript installed as dependency, then to global tsc installation.",
           type: "string",
       },
       o: {
@@ -32,8 +32,8 @@ const argv = yargs
       m: {
           alias: "mocha",
           demand: false,
-          default: "./node_modules/mocha/bin/mocha",
-          describe: "Path to executable mocha, by default points to mocha installed as dev dependency.",
+          default: "mocha",
+          describe: "Path to executable mocha, by default points to mocha installed as dependency, then to global mocha installation.",.",
           type: "string",
       },
       n: {


### PR DESCRIPTION
This is an issue for lerna projects, forcing the path of the binary is not the correct behavior, the .bin is at the project level and not the package level.
Npm has already a way to pick the correct binary we should keep this behavior by default.

Example :
```
➜  test_bin cat package.json|grep test
  "name": "test_bin",
    "test": "tsc --version"
➜  test_bin npm run test    

> test_bin@1.0.0 test /home/david/Code/tests/test_bin
> tsc --version

Version 3.7.2
➜  test_bin rm -Rf node_modules 
➜  test_bin npm run test       

> test_bin@1.0.0 test /home/david/Code/tests/test_bin
> tsc --version

message TS6029: Version 1.5.3
```