### PR TITLE
fix #265: support running afterAll/afterEach hooks in reverse order

### DIFF
--- a/packages/core/test.ts
+++ b/packages/core/test.ts
@@ -18,11 +18,10 @@ class LoggingClassTestUI extends ClassTestUI {
     public log: LoggingClassTestUI.Log;
     private readonly logger: LoggingClassTestUI.LoggingRunner;
     constructor() {
-        const runner = new LoggingClassTestUI.LoggingRunner();
-        super(runner);
+        super(new LoggingClassTestUI.LoggingRunner());
         this.log = LoggingClassTestUI.Log.Default;
-        runner.ui = this;
-        this.logger = runner;
+        (this.runner as LoggingClassTestUI.LoggingRunner).ui = this;
+        this.logger = this.runner as LoggingClassTestUI.LoggingRunner;
     }
     get root(): LoggingClassTestUI.ChildInfo[] { return this.logger.peek; }
 }

--- a/packages/jasmine/index.ts
+++ b/packages/jasmine/index.ts
@@ -48,6 +48,8 @@ const jestRunner: core.TestRunner = {
 };
 
 class JestClassTestUI extends core.ClassTestUI {
+  public readonly executeAfterHooksInReverseOrder: boolean = true;
+
   public constructor(runner: core.TestRunner = jestRunner) {
     super(runner);
   }

--- a/packages/jest/index.ts
+++ b/packages/jest/index.ts
@@ -48,6 +48,8 @@ const jestRunner: core.TestRunner = {
 };
 
 class JestClassTestUI extends core.ClassTestUI {
+  public readonly executeAfterHooksInReverseOrder: boolean = true;
+
   public constructor(runner: core.TestRunner = jestRunner) {
     super(runner);
   }


### PR DESCRIPTION
fix #265: support running afterAll/afterEach hooks in reverse order