### PR TITLE
fix #267: add missing keywords to package manifest

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,6 +2,15 @@
   "name": "@testdeck/core",
   "version": "0.0.8",
   "description": "Core framework for decorator based object oriented testing",
+  "keywords": [
+    "test",
+    "testing",
+    "typescript",
+    "bdd",
+    "tdd",
+    "object oriented",
+    "object-oriented"
+  ],
   "author": "Panayot Cankov",
   "contributors": [
     {

--- a/packages/jasmine/package.json
+++ b/packages/jasmine/package.json
@@ -2,6 +2,16 @@
   "name": "@testdeck/jasmine",
   "version": "0.0.8",
   "description": "Object oriented testing for the Jasmine test framework",
+  "keywords": [
+    "test",
+    "testing",
+    "jasmine",
+    "typescript",
+    "bdd",
+    "tdd",
+    "object oriented",
+    "object-oriented"
+  ],
   "author": "Panayot Cankov",
   "contributors": [
     {

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -2,6 +2,16 @@
   "name": "@testdeck/jest",
   "version": "0.0.8",
   "description": "Object oriented testing for the Jest test framework",
+  "keywords": [
+    "test",
+    "testing",
+    "jest",
+    "typescript",
+    "bdd",
+    "tdd",
+    "object oriented",
+    "object-oriented"
+  ],
   "author": "Panayot Cankov",
   "contributors": [
     {

--- a/packages/mocha/package.json
+++ b/packages/mocha/package.json
@@ -2,6 +2,16 @@
   "name": "@testdeck/mocha",
   "version": "0.0.8",
   "description": "Object oriented testing for the Mocha test framework",
+  "keywords": [
+    "test",
+    "testing",
+    "mocha",
+    "typescript",
+    "bdd",
+    "tdd",
+    "object oriented",
+    "object-oriented"
+  ],
   "author": "Panayot Cankov",
   "contributors": [
     {


### PR DESCRIPTION
fix #267: add missing keywords to package manifest