### PR TITLE
fix gh-254: use Object.getOwnPropertyDescriptor instead of accessing the fields directly

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -135,18 +135,11 @@ export abstract class ClassTestUI {
       let currentPrototype = prototype;
       while (currentPrototype !== Object.prototype) {
         Object.getOwnPropertyNames(currentPrototype).forEach((key) => {
-          // Issue #248: getters and setters declared by classes may result in error
-          // and accessing the property by name will directly invoke either one
-          try {
-            if (typeof prototype[key] === "function") {
-              const method = prototype[key];
-              if (method[ClassTestUI.nameSymbol] && !collectedTests[key]) {
-                collectedTests[key] = [prototype, method];
-              }
-            }
-          } catch (ignored) {
-            // getter or setter
-            // just ignore, even though it is a costly operation
+          const descriptor = Object.getOwnPropertyDescriptor(currentPrototype, key);
+          if (typeof descriptor.value === 'function'
+              && descriptor.value[ClassTestUI.nameSymbol]
+              && !collectedTests[key]) {
+            collectedTests[key] = [prototype, descriptor.value];
           }
         });
         currentPrototype = (Object as any).getPrototypeOf(currentPrototype);


### PR DESCRIPTION
fix gh-254: use Object.getOwnPropertyDescriptor instead of accessing the fields directly.