### PR TITLE
Fix #276

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -223,11 +223,11 @@ export abstract class ClassTestUI {
         if (isAsync(constructor.after)) {
           theTestUI.runner.afterAll("static after", wrap(function(done) {
             return constructor.after(done);
-          }, constructor.after), theTestUI.getSettings(constructor.before));
+          }, constructor.after), theTestUI.getSettings(constructor.after));
         } else {
           theTestUI.runner.afterAll("static after", wrap(function() {
             return constructor.after();
-          }, constructor.after), theTestUI.getSettings(constructor.before));
+          }, constructor.after), theTestUI.getSettings(constructor.after));
         }
       }
     };

--- a/packages/core/test.ts
+++ b/packages/core/test.ts
@@ -499,6 +499,17 @@ describe("testdeck", function() {
                 }]
             }]);
         });
+
+        it("gh-276: regression static after only must not result in error", function() {
+
+            ui.log = LoggingClassTestUI.Log.SetupTeardown;
+
+            assert.doesNotThrow(function() {
+                @ui.suite class SomeSuite {
+                    public static after() {}
+                }
+            });
+        });
     });
 
     describe("lifecycle hooks", function() {


### PR DESCRIPTION
This fix will remove `TypeError: Cannot use 'in' operator to search for '__testdeck_slow' in undefined` error.
Like other hooks, `theTestUI.getSettings()` call should get settings from itself.