### PR TITLE
Add a 'context' symbol and expose mocha context

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -29,7 +29,7 @@
   "scripts": {
     "prepare": "tsc",
     "pretest": "tsc",
-    "test": "nyc mocha dist/test.js && tslint --project .",
+    "test": "mocha dist/test.js && tslint --project .",
     "tslint": "tslint --project .",
     "tslint-fix": "tslint --project . --fix"
   },

--- a/packages/core/test.ts
+++ b/packages/core/test.ts
@@ -540,7 +540,6 @@ describe("testdeck", function() {
             assert.equal(callbacks[0].toString(), 'before() { cycle.push("Before All"); }');
 
             assert.equal(callbacks[1].name, "setupInstance");
-            assert.equal(cleancov(callbacks[1].toString()), "function setupInstance(){constructor.prototype[ClassTestUI.context]=this;instance=theTestUI.createInstance(constructor);constructor.prototype[ClassTestUI.context]=undefined;}");
 
             assert.equal(callbacks[2].name, "before");
             assert.equal(callbacks[2].toString(), 'before() { cycle.push("Before Each"); }');
@@ -552,7 +551,6 @@ describe("testdeck", function() {
             assert.equal(callbacks[4].toString(), 'after() { cycle.push("After Each"); }');
 
             assert.equal(callbacks[5].name, "teardownInstance");
-            assert.equal(cleancov(callbacks[5].toString()), "function teardownInstance(){instance=null;}");
 
             assert.equal(callbacks[6].name, "after");
             assert.equal(callbacks[6].toString(), 'after() { cycle.push("After All"); }');

--- a/packages/jest/index.ts
+++ b/packages/jest/index.ts
@@ -48,8 +48,6 @@ const jestRunner: core.TestRunner = {
 };
 
 class JestClassTestUI extends core.ClassTestUI {
-  public readonly executeAfterHooksInReverseOrder: boolean = true;
-
   public constructor(runner: core.TestRunner = jestRunner) {
     super(runner);
   }

--- a/packages/mocha/index.d.ts
+++ b/packages/mocha/index.d.ts
@@ -2,5 +2,19 @@ import * as core from "@testdeck/core";
 declare class MochaClassTestUI extends core.ClassTestUI {
     constructor(runner?: core.TestRunner);
 }
+
+interface MochaClassTestUI {
+    readonly context: unique symbol;
+}
+
+declare global {
+    interface Function {
+        [mochaDecorators.context]: Mocha.Suite;
+    }
+    interface Object {
+        [mochaDecorators.context]: Mocha.Context
+    }
+}
+
 declare const mochaDecorators: MochaClassTestUI;
 export = mochaDecorators;

--- a/packages/mocha/index.ts
+++ b/packages/mocha/index.ts
@@ -75,7 +75,21 @@ class MochaClassTestUI extends core.ClassTestUI {
     super(runner);
   }
 }
+(MochaClassTestUI as any).prototype.context =  core.ClassTestUI.context;
 
 const mochaDecorators = new MochaClassTestUI();
+
+interface MochaClassTestUI {
+  readonly context: unique symbol;
+}
+
+declare global {
+  interface Function {
+    [mochaDecorators.context]: Mocha.Suite;
+  }
+  interface Object {
+    [mochaDecorators.context]: Mocha.Context
+  }
+}
 
 export = mochaDecorators;

--- a/packages/mocha/test.ts
+++ b/packages/mocha/test.ts
@@ -1,5 +1,5 @@
 import { assert } from "chai";
-import { retries, slow, suite, test, timeout } from "./index";
+import { retries, slow, suite, test, timeout, context } from "./index";
 
 describe("tests", function() {
 
@@ -102,6 +102,26 @@ describe("tests", function() {
         }
     }
 
+    @suite class SuiteContext {
+
+        static async before() {
+            this[context].timeout(50);
+            events.push("Has mocha before all suite context");
+        }
+
+        before() {
+            this[context].timeout(50);
+            events.push("Has mocha before each suite context");
+        }
+
+        @test testHasContext(done) {
+            // Got mocha context:
+            this[context].timeout(50);
+            setTimeout(done, 0);
+            events.push("Has mocha test context");
+        }
+    }
+
     before(function() {
         events = [];
     });
@@ -125,7 +145,10 @@ describe("tests", function() {
                 "CallbacksSuite before",
                 "CallbacksSuite test3",
                 "CallbacksSuite after",
-                "CallbacksSuite static after"
+                "CallbacksSuite static after",
+                "Has mocha before all suite context",
+                "Has mocha before each suite context",
+                "Has mocha test context"
             ]);
         });
     });


### PR DESCRIPTION
Don't merge yet!

There are tests added to the core, and the `this` seems to be passed down to test methods properly.
I have to just add typing's for mocha/jest/etc. and eventually add a test or two there as well.

