### PR TITLE
Use new mocha options flag and config

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 15.x]
+        node-version: [12.x, 14.x, 15.x, 16.x, 17.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/packages/mocha/bin/watch
+++ b/packages/mocha/bin/watch
@@ -26,8 +26,8 @@ const argv = yargs
       o: {
           alias: "opts",
           demand: false,
-          default: "./test/mocha.opts",
-          describe: "Path to mocha.opts file containing additional mocha configuration.",
+          default: "./test/.mocharc.json",
+          describe: "Path to file containing additional mocha configuration.",
           type: "string",
       },
       m: {
@@ -92,7 +92,7 @@ function compilationComplete() {
 
     const mochaOptions = ["--colors"].concat(argv._);
     if (argv.opts && fs.existsSync(argv.opts)) {
-        mochaOptions.push("--opts");
+        mochaOptions.push("--options");
         mochaOptions.push(argv.opts);
     }
     if (argv.g) {


### PR DESCRIPTION
Passes new `--options` flag to mocha

Fixes #289