### PR TITLE
Fix the execution order for jest-jasmine2

### DIFF
--- a/packages/jest/index.ts
+++ b/packages/jest/index.ts
@@ -48,6 +48,9 @@ const jestRunner: core.TestRunner = {
 };
 
 class JestClassTestUI extends core.ClassTestUI {
+  // Jest can still use jasmine2 as a test runner.
+  public readonly executeAfterHooksInReverseOrder = Boolean(global.jasmine);
+
   public constructor(runner: core.TestRunner = jestRunner) {
     super(runner);
   }

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -30,7 +30,7 @@
   "scripts": {
     "prepare": "tsc",
     "pretest": "tsc",
-    "test": "jest dist/test.js && tslint --project .",
+    "test": "jest dist/test.js && jest --testRunner=jest-jasmine2 dist/test.js && tslint --project .",
     "tslint": "tslint --project .",
     "tslint-fix": "tslint --project . --fix"
   },


### PR DESCRIPTION
Jest changed the default test runner as `jest-circus` in v27.
But users can still use `jasmine2` as a test runner by changing the settings.
However, there is a difference between `jest-circus` and `jasmine2` which is execution order of `afterEach` method.
Due to execution order, if the user runs a test which has `after` method with `jasmine2` runner, the test will fail.
To fix this issue, I reverted the `executeAfterHooksInReverseOrder` property and set the value by `jasmine` in global scope.

I've also thought some other methods to solve this issue which are
- Register the teardown method to both ends of suite's `after` method and ignoring the first one.
- Just merge the teardown method with suite's `after` method

But I thought this way is more simple but effective.